### PR TITLE
Blocking transpose

### DIFF
--- a/isodistrreg/src/routines.rs
+++ b/isodistrreg/src/routines.rs
@@ -3,7 +3,17 @@ use std::cmp::Ordering;
 use std::iter::once;
 use std::mem;
 
-/// Transposes a row-major `m × n` matrix stored in `slice`.
+/// Tile size for the blocked transposes. Chosen so a `BLOCK × BLOCK` `f32` tile
+/// (and the two windows the off-diagonal swap touches) sits comfortably in L1d.
+const BLOCK: usize = 32;
+
+/// Transposes a row-major `m × n` matrix stored in `matrix`.
+///
+/// The square (`m == n`) case is done in place with no extra allocation — at the
+/// sizes that dominate the IDR fit (uncensored uniform, where `m == n` and the
+/// matrix is multiple GB), allocating a second buffer would double peak RSS.
+/// Rectangular matrices need a copy; we still walk in tiles so the strided read
+/// stays in L1.
 pub fn transpose<T: Copy>(matrix: &mut Vec<T>, m: usize, n: usize) {
     assert_eq!(matrix.len(), m * n);
     if m == 0 || n == 0 {
@@ -11,21 +21,44 @@ pub fn transpose<T: Copy>(matrix: &mut Vec<T>, m: usize, n: usize) {
     }
 
     if m == n {
-        // In-place symmetric swap across the diagonal
-        for i in 0..m {
-            for j in (i + 1)..n {
-                matrix.swap(i * n + j, j * n + i);
+        let mut ii = 0;
+        while ii < m {
+            let i_end = (ii + BLOCK).min(m);
+            for i in ii..i_end {
+                for j in (i + 1)..i_end {
+                    matrix.swap(i * n + j, j * n + i);
+                }
             }
+            let mut jj = ii + BLOCK;
+            while jj < m {
+                let j_end = (jj + BLOCK).min(m);
+                for i in ii..i_end {
+                    for j in jj..j_end {
+                        matrix.swap(i * n + j, j * n + i);
+                    }
+                }
+                jj += BLOCK;
+            }
+            ii += BLOCK;
         }
         return;
     }
 
-    let mut out = Vec::with_capacity(matrix.len());
-    // Iterate by the new index
-    for i in 0..n {
-        for j in 0..m {
-            out.push(matrix[j * n + i]);
+    let mut out: Vec<T> = matrix.clone();
+    let mut ii = 0;
+    while ii < n {
+        let i_end = (ii + BLOCK).min(n);
+        let mut jj = 0;
+        while jj < m {
+            let j_end = (jj + BLOCK).min(m);
+            for i in ii..i_end {
+                for j in jj..j_end {
+                    out[i * m + j] = matrix[j * n + i];
+                }
+            }
+            jj += BLOCK;
         }
+        ii += BLOCK;
     }
     *matrix = out;
 }


### PR DESCRIPTION
### Cache-blocked transpose (≈ 2× faster fit at large n)

`routines::transpose` is called once at the end of every fit to flip the CDF matrix from threshold-major to covariate-major. `perf` on a 25 000 uncensored uniform fit had this transpose at **56 % of total wall time** — the naive column-strided write blows past L3 on every cache line at n ≥ ~5 000.

This PR replaces the inner loops with a 32×32 blocked transpose: in-place swap-within-tile for the square (`m == n`) case, blocked read+copy for the rectangular case. Tile size is chosen so two 32×32 f32 tiles (8 KB) fit in the smallest mainstream L1d (32 KB) with associativity headroom.

Wall-clock of `IDR(y, X)` on totally-ordered uniform data, same machine, release build, `OPENBLAS_NUM_THREADS=1`, median of 3–5 trials.

| n       | before  | after   | speedup |
| ------: | ------: | ------: | ------: |
|   1 000 |  3.7 ms |  3.6 ms |   1.03× |
|   5 000 |  119 ms |   90 ms |   1.32× |
|  25 000 |  4.75 s |  2.85 s |   1.67× |
|  50 000 | 24.85 s | 11.84 s |   2.10× |

Combined with the f32 conversion (PR #9), uncensored fit at n = 50 000 went from ~30 s and 19 GB RSS to **11.8 s and 9.6 GB**.

#### Alternatives considered

- **`transpose` crate, out-of-place.** ~1.84× at n=50k (slightly slower  than the hand-rolled in-place version) and transiently doubles peak RSS  to 19 GB — undoing the memory win from #9.
- **`transpose::transpose_inplace`.** ~0.13× (8× slower than the naive  baseline). Its "in-place" uses an N-element scratch and a column-strided read pattern, equivalent to the naive transpose plus overhead. Optimised for memory-tight scenarios, not for speed.
- **Direct strided write during the fit** (replacing the transpose with per-threshold strided stores into a pre-allocated covariate-major buffer). ~0.59× — strided writes are no cheaper than strided reads, and the baseline at least had a sequential write phase.
- **Hand-rolled AVX2 8×8 in-register transpose** with runtime feature dispatch. Gives ~1.08× at n=5k, vanishes to noise at n=25k, and is slightly negative at n=50k. The transpose is memory-bandwidth-bound at the sizes that matter, so SIMD speeds up the inner kernel while it sits idle waiting for DRAM. Not worth ~140 LOC of unsafe x86_64 intrinsics plus a non-x86 fallback.