### PR TITLE
Drop the write-only per-cell clip-bounds array in censored S-IDR

### DIFF
--- a/isodistrreg/src/total_order/stochastic_dominance/censored/fast.rs
+++ b/isodistrreg/src/total_order/stochastic_dominance/censored/fast.rs
@@ -287,13 +287,7 @@ fn initialize<D: Direction, X: crate::Float, Y: crate::Float>(
         cold.raw_value = raw_value;
         cold.weight = obs_weight;
         cold.count = (data_index + 1) as u32;
-        // The estimators (r, cov_index) are decreasing in r, so the lower bound is below the value
         estimators.set_value(idx, row_idx, raw_value);
-
-        // Propagate bound
-        if r > 0 {
-            estimators.bounds_mut(r - 1, obs_x).0 = raw_value;
-        }
     }
 
     // Set up partitions
@@ -575,11 +569,11 @@ fn pool<W, V, D: Direction, K: Kernel, X: crate::Float, Y: crate::Float>(
         // larger r within the same tile — so the tiled order is a valid schedule of the
         // same DP and every cell sees identical inputs (bit-identical results). The point
         // of the tiles: wide merges revisit each column once per row, and with the full
-        // span in flight the columns (plus their bounds and K-M state) fall out of L2
-        // between visits; a tile's working set stays cache-resident across the r sweep.
-        // One cell: kernel, then K-M update. Index and bounds flow through registers
-        // between the two — the bounds/value stores remain for future readers, but the
-        // consecutive-cell dependency chain skips the memory round-trip.
+        // span in flight the columns (plus their K-M state) fall out of L2 between visits;
+        // a tile's working set stays cache-resident across the r sweep.
+        // One cell: kernel, then K-M update. Index and bounds flow through registers between
+        // the two — bounds are never stored (only the value store remains for future readers),
+        // so the consecutive-cell dependency chain skips the memory round-trip.
         #[inline(always)]
         #[allow(clippy::too_many_arguments)]
         fn cell<K: Kernel, X: crate::Float, Y: crate::Float>(
@@ -682,12 +676,6 @@ impl Estimates {
         debug_assert_eq!(
             idx,
             Self::compute_index((covariate_start_index, covariate_end_index), self.len()),
-        );
-        // Bitwise comparison: diagonal cells carry the (NAN, NAN) sentinel, which `==` would
-        // reject even when the pair is byte-identical to the stored bounds.
-        debug_assert_eq!(
-            (bounds.0.to_bits(), bounds.1.to_bits()),
-            (self.bounds[idx].0.to_bits(), self.bounds[idx].1.to_bits()),
         );
         let row_idx =
             Self::compute_row_index((covariate_start_index, covariate_end_index), self.len());
@@ -799,7 +787,10 @@ impl Estimates {
             let bounds = if r < observation.x {
                 self.propagate_bounds_with_row::<K>(idx, r, observation.x)
             } else {
-                self.bounds[idx]
+                // Diagonal (singleton) cell: no subdivisions, so no clip bounds. The
+                // (NaN, NaN) sentinel makes `update_value`'s `lower >= upper` collapse
+                // check false and the final `max(NaN).min(NaN)` clip a no-op.
+                (f32::NAN, f32::NAN)
             };
             self.update_value::<K, _, _>(
                 data_index,
@@ -818,9 +809,10 @@ impl Estimates {
     /// contiguously from the row-major mirror) paired with the column operand
     /// `values[(r+1..=s, s)]` (contiguous in the column-major triangle).
     ///
-    /// `idx` must be `compute_index((r, s))`. The fresh bounds are stored *and* returned, so
-    /// the immediately following `update_value` keeps them in registers.
-    fn propagate_bounds_with_row<K: Kernel>(&mut self, idx: usize, r: usize, s: usize) -> Bounds {
+    /// `idx` must be `compute_index((r, s))`. The bounds are only ever consumed by the
+    /// `update_value` that immediately follows (kept in registers), so they are returned
+    /// rather than stored — no per-cell bounds array is maintained.
+    fn propagate_bounds_with_row<K: Kernel>(&self, idx: usize, r: usize, s: usize) -> Bounds {
         assert!(r < s);
         assert!(s < self.len());
 
@@ -831,10 +823,7 @@ impl Estimates {
         let row = &self.values_row[row_start..row_start + len];
         let col = &self.values[col_s_base + r + 1..=col_s_base + s];
 
-        let bounds = K::apply(row, col);
-
-        self.bounds[idx] = bounds;
-        bounds
+        K::apply(row, col)
     }
 }
 

--- a/isodistrreg/src/total_order/stochastic_dominance/censored/structures.rs
+++ b/isodistrreg/src/total_order/stochastic_dominance/censored/structures.rs
@@ -106,9 +106,8 @@ impl CompletionIndex {
 }
 
 /// The Kaplan-Meier running state of one (r, s) cell — only touched when `update_value`
-/// actually folds observations, unlike the bounds, which every `propagate_bounds` call
-/// rewrites. Kept in a separate array (12 bytes vs 8 for the bounds pair) so each path only
-/// streams the bytes it uses.
+/// actually folds observations. Kept in its own array (12 bytes) so the hot bound-propagation
+/// reader streams only the contiguous `values`/`values_row` it needs.
 #[derive(Clone, Debug)]
 pub struct SurvivalComputationCold {
     /// The Kaplan-Meier estimator (based on `count` samples). Updated incrementally inside
@@ -122,8 +121,9 @@ pub struct SurvivalComputationCold {
     pub count: u32,
 }
 
-/// Lower/upper clip bound of one (r, s) cell — NAN for diagonal singletons. Written as a pair
-/// by every `propagate_bounds` call; read as a pair by `update_value`.
+/// Lower/upper clip bound of one (r, s) cell — `(NaN, NaN)` for diagonal singletons.
+/// Produced by `propagate_bounds_with_row` and consumed by `update_value` in the same step;
+/// flows through registers, never stored in a per-cell array.
 pub type Bounds = (f32, f32);
 
 /// Stores partial survival / Kaplan-Meier estimator computations for all sub intervals.
@@ -144,8 +144,6 @@ pub struct Estimates {
     /// (one cache line per element), which measured at ~26% of kernel-bound fits. Every
     /// value write maintains both copies (the second store is sequential and cheap).
     pub values_row: Vec<f32>,
-    /// (lower, upper) clip bound of each (r, s). Indexed identically to `values`.
-    pub bounds: Vec<Bounds>,
     /// K-M running state of each (r, s). Indexed identically to `values`.
     pub cold: Vec<SurvivalComputationCold>,
     /// Exact-0 completion oracle. Consulted on every cell write so that intervals whose
@@ -172,7 +170,6 @@ impl Estimates {
         let total = n * (n + 1) / 2;
         let values = vec![1.0; total];
         let values_row = vec![1.0; total];
-        let mut bounds = vec![(1.0f32, 1.0f32); total];
         let cold = vec![
             SurvivalComputationCold {
                 raw_value: 1.0,
@@ -181,13 +178,6 @@ impl Estimates {
             };
             total
         ];
-        // Diagonal entries don't have meaningful bounds (no subdivisions); mark with NAN so the
-        // bounds-equality short-circuit in `update_value` would only fire on actually-collapsed
-        // intervals.
-        for i in 0..n {
-            let idx = Self::compute_index((i, i), n);
-            bounds[idx] = (f32::NAN, f32::NAN);
-        }
         // Covariate indices share their u32 with the flag in the top bit; `MAX_OBSERVATIONS`
         // keeps them below it (the largest covariate index is at most `observations.len() - 1`).
         debug_assert!(observations.len() <= MAX_OBSERVATIONS);
@@ -200,7 +190,6 @@ impl Estimates {
             len: n,
             values,
             values_row,
-            bounds,
             cold,
             completion,
             walk_x,
@@ -233,11 +222,6 @@ impl Estimates {
     #[inline(always)]
     pub fn value(&self, r: usize, s: usize) -> f32 {
         self.values[Self::compute_index((r, s), self.len)]
-    }
-    /// Mutable access to the clip bounds at (r, s).
-    #[inline(always)]
-    pub fn bounds_mut(&mut self, r: usize, s: usize) -> &mut Bounds {
-        &mut self.bounds[Self::compute_index((r, s), self.len)]
     }
     /// Write the clipped value at `idx` = (r, s), maintaining the row-major mirror.
     #[inline(always)]


### PR DESCRIPTION
We don't need to track the bound values, just the original and clipped values.

`propagate_bounds_with_row` computes a cell's (lower, upper) clip bounds and hands them straight to the `update_value` that immediately follows. Since the row-major-mirror change started passing those bounds through registers, that hand-off is their only consumer: `Estimates::bounds` was still written on every cell (hot `propagate_bounds_with_row`, and `initialize`) but in release it was never read back. The only release reads were the diagonal `(NaN, NaN)` sentinels (`update_partial_row`'s `r == x` case) and a debug-only equality assert; the DP never feeds a stored bound into any computation — the kernel always recomputes from the `values` / `values_row` operands.

Remove the array entirely:
  - `propagate_bounds_with_row` returns the bounds without storing them (now takes `&self`);
  - the diagonal case passes the `(NaN, NaN)` sentinel as a literal;
  - `initialize`'s dead lower-bound propagation and the bounds-match debug assert are dropped.

This removes one store per cell from the hot loop and, more importantly, a whole O(m^2) array from the tiled merge working set, so the kernel operand reads and the K-M `cold` state stay cache-resident across the r sweep. The hot loop is memory/throughput-bound (a `-C target-cpu=native` build is *slower* on these cells), so dropping a per-cell memory stream is the win.

Bit-identical by construction (the stored bounds were never an input), and verified bit-identical across the whole grid. Paired A/B, 5 seeds:
  - 20-cell round-1 grid:        geo-mean 0.941
  - 22-cell round-2 large grid:  geo-mean 0.944
Wins concentrate on the kernel-dominated continuous-covariate (large unique-
covariate-count m) cells — the slowest cases at fixed n — at 0.83-0.95;
preprocessing-bound discrete cells (m << n) are neutral as expected. 227 tests
pass with --all-features (incl. the differential suite vs the reference and the
cross-SIMD kernel-equivalence tests).