### PR TITLE
Checks to assert correctness

### DIFF
--- a/isodistrreg/src/total_order/preprocessing.rs
+++ b/isodistrreg/src/total_order/preprocessing.rs
@@ -100,12 +100,19 @@ pub fn preprocess<X: Float, Y: Float, S: Ord, W: Float, F: Fn(usize) -> S>(
         observed: S,
         weight: W,
     }
+    // Canonicalize signed zeros while packing (`-0.0 + 0.0 == +0.0` in IEEE
+    // round-to-nearest; every other value is unchanged): the sort keys use `total_cmp`,
+    // which separates -0.0 from +0.0, while the aggregation below merges them with `==`.
+    // Mixed zeros would otherwise assemble one covariate or threshold out of two
+    // sort-distinct groups — leaving duplicate observations non-adjacent (escaping
+    // deduplication) and a threshold's events not ascending in covariate, both contracts
+    // the PAVA batching depends on.
     let mut items: Vec<Item<X, Y, S, W>> = izip!(x, y, weight)
         .enumerate()
         .filter(|&(_, (_, _, &weight))| weight > W::zero())
         .map(|(index, (&x, &y, &weight))| Item {
-            x,
-            y,
+            x: x + X::zero(),
+            y: y + Y::zero(),
             observed: observed(index),
             weight,
         })
@@ -275,11 +282,15 @@ pub fn preprocess_censored<X: Float, Y: Float, W: Float>(
             weight: W,
             observed: bool,
         }
+        // Canonicalize signed zeros while packing, exactly as in `preprocess`: the
+        // `total_cmp` sort keys must agree with the `==` aggregation below on ±0.0, or a
+        // merged threshold's events end up not ascending in covariate and duplicate
+        // covariates escape deduplication — contracts the batched PAVA updates rely on.
         let mut items: Vec<Item<X, Y, W>> = izip!(x, y, observed, weights)
             .filter(|&(_, _, _, &weight)| weight > W::zero())
             .map(|(&x, &y, &observed, &weight)| Item {
-                y,
-                x,
+                y: y + Y::zero(),
+                x: x + X::zero(),
                 weight,
                 observed,
             })

--- a/isodistrreg/src/total_order/stochastic_dominance/censored/fast.rs
+++ b/isodistrreg/src/total_order/stochastic_dominance/censored/fast.rs
@@ -7,6 +7,8 @@ use crate::total_order::stochastic_dominance::censored::propagate_bounds::{
     Avx2Kernel, Avx512Kernel,
 };
 use crate::total_order::stochastic_dominance::censored::propagate_bounds::{Kernel, ScalarKernel};
+#[cfg(debug_assertions)]
+use crate::total_order::stochastic_dominance::censored::structures::WALK_OBSERVED_BIT;
 use crate::total_order::stochastic_dominance::censored::structures::{
     Bounds, CompletionIndex, Estimates, Partition,
 };
@@ -21,10 +23,90 @@ use std::iter::repeat_n;
 mod sweep;
 use sweep::{SweepArgs, SweepDispatch};
 
+/// Debug-only formalization of the preprocessing contract (see `preprocess_censored`)
+/// that every stage of this module silently depends on:
+///
+/// - observations sorted by threshold index, each threshold's events forming one
+///   contiguous run (strictly ascending covariate, duplicates aggregated) before the
+///   threshold's censored observations — the run gathering, the batched update, and the
+///   walk ranges of `update_value` all assume this order;
+/// - the first observation is an event at threshold 0 and every threshold owns at least
+///   one event (thresholds are exactly the unique event responses), so the threshold
+///   loop consumes every observation;
+/// - censored observations are snapped to the latest threshold at or below their
+///   response (`y < n_threshold`), so none survives past the final threshold;
+/// - every weight is positive (the kernels divide by observation and covariate weights)
+///   and the cumulative covariate weights chain by ONE addition per covariate — the
+///   accumulation the `weight_noise_floor` bound and the branch-free `cum_w` differences
+///   reason about.
+#[cfg(debug_assertions)]
+fn assert_preprocessing_contract<X: crate::Float, Y: crate::Float>(
+    context: &CensoredContext<X, Y>,
+) {
+    let n_covariate = context.n_covariate();
+    let n_threshold = context.n_threshold();
+
+    let mut threshold_has_event = vec![false; n_threshold];
+    for o in &context.observations {
+        assert!(o.x < n_covariate, "covariate index outside the grid");
+        assert!(o.y < n_threshold, "threshold index outside the grid");
+        assert!(o.weight > 0.0, "zero-weight observations must be dropped");
+        if o.observed {
+            threshold_has_event[o.y] = true;
+        }
+    }
+    assert!(
+        threshold_has_event.iter().all(|&has| has),
+        "every threshold must own at least one event",
+    );
+    if let Some(first) = context.observations.first() {
+        assert!(
+            first.observed && first.y == 0,
+            "censored observations below the first event must be discarded",
+        );
+    }
+    for w in context.observations.windows(2) {
+        let (a, b) = (&w[0], &w[1]);
+        assert!(a.y <= b.y, "observations must be sorted by threshold");
+        if a.y == b.y {
+            assert!(
+                a.observed || !b.observed,
+                "a threshold's events must precede its censored observations",
+            );
+            if a.observed && b.observed {
+                assert!(
+                    a.x < b.x,
+                    "a threshold's events must be strictly ascending in covariate",
+                );
+            }
+        }
+    }
+
+    let statistics = &context.covariate_statistics;
+    assert_eq!(statistics.len(), n_covariate);
+    if let Some(first) = statistics.first() {
+        assert!(first.weight > 0.0);
+        assert_eq!(first.cumulative_weight, first.weight);
+    }
+    for w in statistics.windows(2) {
+        assert!(
+            w[1].weight > 0.0,
+            "empty covariates must not enter the grid"
+        );
+        assert_eq!(
+            w[1].cumulative_weight,
+            w[0].cumulative_weight + w[1].weight,
+            "cumulative weights must chain by one addition per covariate",
+        );
+    }
+}
+
 pub fn algorithm<D: Direction, X: crate::Float, Y: crate::Float>(
     context: &CensoredContext<X, Y>,
     progress: &dyn ProgressTracker,
 ) -> Vec<f32> {
+    #[cfg(debug_assertions)]
+    assert_preprocessing_contract(context);
     progress.set_total(context.n_threshold());
 
     if context.n_threshold() == 0 {
@@ -123,6 +205,11 @@ pub fn algorithm<D: Direction, X: crate::Float, Y: crate::Float>(
                 );
             }
             progress.increment();
+            debug_assert_eq!(
+                cdfs.len(),
+                context.n_threshold() * context.n_covariate(),
+                "the specialized final threshold must complete the output matrix",
+            );
             return cdfs;
         }
 
@@ -177,6 +264,11 @@ pub fn algorithm<D: Direction, X: crate::Float, Y: crate::Float>(
         progress,
     );
 
+    debug_assert_eq!(
+        cdfs.len(),
+        context.n_threshold() * context.n_covariate(),
+        "one full covariate row per threshold",
+    );
     cdfs
 }
 
@@ -235,6 +327,8 @@ fn finalize_for_censoring_only_in_final_threshold<
     // whose CDF is mathematically 1. The partition→range mapping mirrors
     // `routines::store_in_cdf`: ascending indices for increasing fits (partition `l`
     // covers `[partitions[l - 1].index, partitions[l].index)`), descending otherwise.
+    #[cfg(debug_assertions)]
+    let mut covered = 0usize;
     for l in 0..partitions.len() {
         let start = if D::IS_INCREASING {
             if l == 0 { 0 } else { partitions[l - 1].index }
@@ -242,12 +336,44 @@ fn finalize_for_censoring_only_in_final_threshold<
             partitions.get(l + 1).map_or(0, |p| p.index)
         };
         let end = partitions[l].index; // exclusive
+        debug_assert!(start < end);
+        #[cfg(debug_assertions)]
+        {
+            covered += end - start;
+            // The doc comment's completion characterization for this path, checked
+            // literally: with all data consumed, a range completes iff it contains no
+            // censored observation at all (every censored observation sorts at/after the
+            // final threshold's events, so it is its covariate's last observation).
+            debug_assert_eq!(
+                completion.completes_with_all_data(start, end - 1),
+                input
+                    .observations
+                    .iter()
+                    .all(|o| o.observed || o.x < start || o.x >= end),
+                "completion oracle disagrees with the no-censoring characterization \
+                 on range [{start}, {end})",
+            );
+        }
         if completion.completes_with_all_data(start, end - 1) {
+            // The pin only corrects f32 drift: the consumed-share value must already sit
+            // at 1.0 up to accumulated rounding noise. A large gap means the pin is
+            // repainting a genuinely different value — a bookkeeping bug, not drift.
+            debug_assert!(
+                (partitions[l].value - 1.0).abs() < 1e-3,
+                "pinning a value far from 1.0: {}",
+                partitions[l].value,
+            );
             partitions[l].value = 1.0;
         }
     }
+    // The partition->range mapping above mirrors `routines::store_in_cdf` for both
+    // directions; tiling the covariate grid exactly is what validates the mirroring.
+    #[cfg(debug_assertions)]
+    debug_assert_eq!(covered, input.n_covariate());
 
     routines::store_in_cdf::<_, D>(&partitions, cdf);
+    #[cfg(debug_assertions)]
+    routines::debug_assert_last_rows_monotone(cdf, input.n_covariate());
 }
 
 fn initialize<D: Direction, X: crate::Float, Y: crate::Float>(
@@ -280,6 +406,7 @@ fn initialize<D: Direction, X: crate::Float, Y: crate::Float>(
         // (any wider range contains another covariate whose observations all sort after
         // this very first one).
         let raw_value = if CompletionIndex::completes_marker(marker_max, data_index) {
+            debug_assert_eq!(r, obs_x, "only the singleton cell can complete here");
             0.0
         } else {
             1.0 - obs_weight / total_weight
@@ -439,9 +566,58 @@ fn generalized_pava<D: Direction, K: SweepDispatch, X: crate::Float, Y: crate::F
             data_index += 1;
         }
 
+        // The stored row must be an antitonic regression: adjacent block values must not
+        // compare in the forbidden ordering. Boundaries at the stack top are verified by
+        // `pool` directly; boundaries restored blind rely on same-cell values being
+        // monotone in `data_index`, which is exact for raw folds, pins, and clips but
+        // can wobble by rounding noise for collapsed-bounds midpoints (per-visit
+        // checkpoint prefixes are mutually unordered) — hence the noise slack instead of
+        // an exact comparison.
+        #[cfg(debug_assertions)]
+        {
+            let mut block_start = 0usize;
+            let mut previous: Option<f32> = None;
+            for partition in partitions.iter() {
+                let value = estimates.value(block_start, partition.index - 1);
+                if let Some(previous) = previous {
+                    let in_order = match D::FORBIDDEN_ORDERING {
+                        Ordering::Greater => previous <= value + routines::MONOTONICITY_NOISE_SLACK,
+                        Ordering::Less => value <= previous + routines::MONOTONICITY_NOISE_SLACK,
+                        Ordering::Equal => unreachable!(),
+                    };
+                    assert!(
+                        in_order,
+                        "adjacent partition values in forbidden ordering at covariate \
+                         {block_start}: {previous} vs {value}",
+                    );
+                }
+                previous = Some(value);
+                block_start = partition.index;
+            }
+        }
+        #[cfg(debug_assertions)]
+        let cdf_len_before = cdf.len();
         store_in_cdf(&estimates, &partitions, cdf);
+        #[cfg(debug_assertions)]
+        {
+            debug_assert_eq!(
+                cdf.len() - cdf_len_before,
+                input.n_covariate(),
+                "a threshold's partitions did not tile the covariate grid",
+            );
+            routines::debug_assert_last_rows_monotone(cdf, input.n_covariate());
+        }
         progress.increment();
     }
+
+    // Every observation is consumed: events drive the updates, and preprocessing snaps
+    // censored observations to the latest threshold at or below their response, so none
+    // sorts past the final threshold.
+    debug_assert_eq!(data_index, input.n());
+    // Every value write maintained both value layouts; a divergence would mean some
+    // kernel reduced a row operand and a column operand from different states.
+    #[cfg(debug_assertions)]
+    estimates.assert_mirrors_coherent();
 }
 
 /// Apply one threshold's events — the run of uncensored observations tied on that
@@ -501,6 +677,17 @@ fn update_threshold<D: Direction, K: SweepDispatch, X: crate::Float, Y: crate::F
 ) {
     // Threshold-end folds throughout: every walk consumes the whole run.
     let data_index = run_end - 1;
+
+    // One threshold's whole event run: non-empty, all observed, one response, covariates
+    // strictly ascending. The deferred-remainder bookkeeping below and the walk ranges
+    // of `update_value` (which absorb the whole run at once) both assume exactly this.
+    #[cfg(debug_assertions)]
+    {
+        let run = &input.observations[run_start..run_end];
+        debug_assert!(!run.is_empty());
+        debug_assert!(run.iter().all(|o| o.observed && o.y == run[0].y));
+        debug_assert!(run.windows(2).all(|w| w[0].x < w[1].x));
+    }
 
     if D::FORBIDDEN_ORDERING == Ordering::Less {
         // TODO
@@ -637,6 +824,12 @@ fn update_threshold<D: Direction, K: SweepDispatch, X: crate::Float, Y: crate::F
     }
     partitions.extend(tmp_partition_store.drain(store_cursor..));
     tmp_partition_store.clear();
+
+    // The rebuilt stack must tile the covariate grid exactly: the split/deferred-
+    // remainder/blind-restore choreography above re-adds every drained covariate
+    // exactly once, and a gap or overlap here silently corrupts every later threshold.
+    debug_assert!(partitions.windows(2).all(|w| w[0].index < w[1].index));
+    debug_assert_eq!(partitions.last().unwrap().index, input.n_covariate());
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -835,6 +1028,23 @@ impl Estimates {
             // clip still has to be reapplied. Skipping it would leave a value clipped against
             // bounds that no longer exist.
             let result = cold.raw_value.max(lower_bound).min(upper_bound);
+            // The guard's soundness claim, checked literally: a remaining weight below
+            // the noise floor means no unconsumed observation can lie in the cell (real
+            // observation weights sit far above the floor — see `weight_noise_floor`),
+            // so the skipped walk range must contain no in-range item. A hit here means
+            // the guard fired on live data, silently freezing the cell's K-M value.
+            #[cfg(debug_assertions)]
+            {
+                let start = covariate_start_index as u32;
+                let span = (covariate_end_index - covariate_start_index) as u32;
+                let from = cold.count as usize;
+                debug_assert!(
+                    self.walk_x[from..data_index + 1]
+                        .iter()
+                        .all(|&x| (x & !WALK_OBSERVED_BIT).wrapping_sub(start) > span),
+                    "noise-floor guard skipped observations that would have folded",
+                );
+            }
             self.set_value(idx, row_idx, result);
             return;
         }
@@ -863,6 +1073,21 @@ impl Estimates {
                 self.walk_w.get_unchecked(from..to),
             )
         };
+        // Debug cross-check: a SIMD walk must fold exactly the same items in the same
+        // order as the scalar reference — bit-identical results here are what keep fits
+        // independent of the host's SIMD level, checked on every real walk rather than
+        // only on the unit test's synthetic streams.
+        #[cfg(debug_assertions)]
+        let walk_reference = (!K::IS_REFERENCE).then(|| {
+            ScalarKernel::walk_scan(
+                walk_xs,
+                walk_ws,
+                covariate_start_index as u32,
+                (covariate_end_index - covariate_start_index) as u32,
+                cold.raw_value,
+                remaining_weight,
+            )
+        });
         let (raw_value, remaining_weight) = K::walk_scan(
             walk_xs,
             walk_ws,
@@ -871,6 +1096,17 @@ impl Estimates {
             cold.raw_value,
             remaining_weight,
         );
+        #[cfg(debug_assertions)]
+        if let Some(reference) = walk_reference {
+            debug_assert_eq!(
+                (raw_value.to_bits(), remaining_weight.to_bits()),
+                (reference.0.to_bits(), reference.1.to_bits()),
+                "SIMD walk diverged from the scalar reference",
+            );
+        }
+        // The noise-floor guard above keeps every K-M denominator the walk divides by
+        // away from zero; a non-finite product means it under-guarded.
+        debug_assert!(raw_value.is_finite());
 
         // SAFETY: as above; re-borrowed because the walk's slice borrows ended the
         // earlier exclusive borrow.
@@ -898,6 +1134,9 @@ impl Estimates {
         input: &CensoredContext<X, Y>,
         epsilon: f32,
     ) {
+        // An empty range here would silently skip the arrival's whole row update — the
+        // partition lookup must have produced the block containing the arrival.
+        debug_assert!(partition_start_index <= observation.x);
         // Completion range-max over `[r, observation.x]`, folded as the loop descends.
         let mut marker_max = 0;
         for r in (partition_start_index..=observation.x).rev() {
@@ -967,11 +1206,30 @@ impl Estimates {
         // never collapse at all. Both dispatch inputs are deterministic and identical
         // across SIMD levels: the length is a static property of the cell, the
         // threshold a pure function of the input data.
-        if len >= self.checkpoint_min_len {
+        let checked = len >= self.checkpoint_min_len;
+        let bounds = if checked {
             K::apply::<true>(row, col)
         } else {
             K::apply::<false>(row, col)
+        };
+        // Debug cross-check against the scalar reference: the shared element-count
+        // checkpoint schedule makes every kernel reduce the same prefix, so the bounds
+        // must be bit-identical — the host-SIMD-independence contract, verified on every
+        // real cell rather than only on the unit test's synthetic slices.
+        #[cfg(debug_assertions)]
+        if !K::IS_REFERENCE {
+            let reference = if checked {
+                ScalarKernel::apply::<true>(row, col)
+            } else {
+                ScalarKernel::apply::<false>(row, col)
+            };
+            debug_assert_eq!(
+                (bounds.0.to_bits(), bounds.1.to_bits()),
+                (reference.0.to_bits(), reference.1.to_bits()),
+                "kernel bounds diverged from the scalar reference at ({r}, {s})",
+            );
         }
+        bounds
     }
 }
 
@@ -983,6 +1241,12 @@ fn store_in_cdf<W, V>(
     partitions: &[structures::Partition<W, V>],
     cdf: &mut Vec<f32>,
 ) {
+    // The partitions must tile `[0, n_covariate)` in strictly ascending order — this is
+    // what makes every `value` read below hit a real block and the emitted row cover
+    // the covariate grid exactly once.
+    debug_assert!(!partitions.is_empty() && partitions[0].index >= 1);
+    debug_assert!(partitions.windows(2).all(|w| w[0].index < w[1].index));
+    debug_assert_eq!(partitions.last().unwrap().index, estimates.len());
     let partition_len = partitions[0].index;
     let value = estimates.value(0, partitions[0].index - 1);
     cdf.extend(repeat_n(1.0 - value.clamp(0.0, 1.0), partition_len));

--- a/isodistrreg/src/total_order/stochastic_dominance/censored/fast/sweep.rs
+++ b/isodistrreg/src/total_order/stochastic_dominance/censored/fast/sweep.rs
@@ -113,6 +113,18 @@ fn sweep_rect_body<K: Kernel, X: crate::Float, Y: crate::Float>(args: SweepArgs<
         left_marker_buf,
     } = args;
 
+    // The merge rectangle must be well-formed: a non-empty row range left of a non-empty
+    // column range, both inside the triangle (`row_end <= ultimate_start` is what makes
+    // every visited cell satisfy r < s, keeping the kernels' operand slices legal), and
+    // each marker buffer covering exactly its range. The caller's row clamp guarantees a
+    // non-empty row range — an empty one would silently skip the whole sweep.
+    debug_assert!(penultimate_start < row_end);
+    debug_assert!(row_end <= ultimate_start);
+    debug_assert!(ultimate_start < ultimate_end);
+    debug_assert!(ultimate_end <= estimates.len());
+    debug_assert_eq!(marker_buf.len(), ultimate_end - ultimate_start);
+    debug_assert_eq!(left_marker_buf.len(), ultimate_start - penultimate_start);
+
     // One cell: kernel, then K-M update. Index and bounds flow through registers between
     // the two — bounds are never stored (only the value store remains for future readers),
     // so the consecutive-cell dependency chain skips the memory round-trip.
@@ -133,6 +145,12 @@ fn sweep_rect_body<K: Kernel, X: crate::Float, Y: crate::Float>(args: SweepArgs<
         // check re-fires on every visit once true (monotone in `data_index`), so
         // this shortcut applies to every revisit of a completed cell.
         if CompletionIndex::completes_marker(marker_max, data_index) {
+            // `marker_max` is composed from the caller's suffix-maxima (penultimate
+            // range) and prefix-maxima (ultimate range) buffers; it must equal the true
+            // completion range-max over the whole cell. The non-completing path is
+            // re-checked inside `update_value`; this pinning path would otherwise go
+            // unchecked — and a too-large composed max pins a live cell to 0 forever.
+            debug_assert_eq!(marker_max, estimates.completion.range_max(r, s));
             let row_idx = Estimates::compute_row_index((r, s), estimates.len());
             debug_assert!(idx < estimates.cold.len());
             // SAFETY: `idx` is the triangle index of (r, s) with r <= s < len.

--- a/isodistrreg/src/total_order/stochastic_dominance/censored/propagate_bounds.rs
+++ b/isodistrreg/src/total_order/stochastic_dominance/censored/propagate_bounds.rs
@@ -63,6 +63,17 @@ use crate::total_order::stochastic_dominance::censored::structures::WALK_OBSERVE
 /// checkpoint exactly.
 const COLLAPSE_CHECK_START: usize = 128;
 
+// The checkpoint tests fire on `k == next_check` equality, so a schedule entry that is not
+// a multiple of some kernel's step is silently skipped by that kernel only — the kernels
+// would then reduce different prefixes and return SIMD-level-dependent bounds, the exact
+// failure mode this schedule exists to rule out. 32 is the largest main-loop step
+// (AVX-512); the smaller steps (16 AVX2, 4 scalar) divide it, and doubling preserves
+// divisibility for every later checkpoint.
+const _: () = assert!(
+    COLLAPSE_CHECK_START.is_multiple_of(32),
+    "checkpoints must be reachable by every kernel's main-loop step",
+);
+
 /// Minimum reduction length for the checkpointed kernel mode — the caller's dispatch
 /// threshold, kept next to the schedule it reasons about. Below it the straight-line
 /// kernel runs: reductions shorter than `COLLAPSE_CHECK_START` cannot reach a checkpoint,
@@ -78,6 +89,12 @@ pub const COLLAPSE_CHECK_MIN_LEN: usize = 384;
 /// associated functions are statically dispatched, so monomorphizing the algorithm tree over
 /// `K: Kernel` inlines them into every callsite.
 pub trait Kernel {
+    /// Marks the semantic reference implementation ([`ScalarKernel`]). Debug builds
+    /// cross-check every `apply`/`walk_scan` result of a non-reference kernel against the
+    /// scalar one at the callsites — bit-equality there is what makes fit results
+    /// independent of the host's SIMD level.
+    const IS_REFERENCE: bool = false;
+
     /// The bound reduction. `CHECKED` enables the collapse checkpoints (see
     /// `COLLAPSE_CHECK_START`); without them the reduction is the exact straight-line
     /// fold over the full slices. Callers pick per cell via the `Estimates::collapsed`
@@ -121,6 +138,13 @@ fn walk_scan_scalar(
         }
         let weight = ws[i];
         if x_flagged & WALK_OBSERVED_BIT != 0 {
+            // The at-risk weight must still be strictly positive at every event fold:
+            // `update_value`'s `weight_noise_floor` guard is what keeps walks away from
+            // drifted-to-zero denominators, and a violation here means it under-guarded
+            // (the product would blow up to inf/NaN). The factor itself may dip a few
+            // ulps below 0 for a cell's last at-risk observation — that is expected
+            // subtraction drift, not a bug, so only positivity is asserted.
+            debug_assert!(remaining_weight > 0.0);
             raw_value *= 1.0 - weight / remaining_weight;
         }
         remaining_weight -= weight;
@@ -132,6 +156,8 @@ fn walk_scan_scalar(
 pub struct ScalarKernel;
 
 impl Kernel for ScalarKernel {
+    const IS_REFERENCE: bool = true;
+
     #[inline(always)]
     fn apply<const CHECKED: bool>(row: &[f32], col: &[f32]) -> (f32, f32) {
         propagate_bounds_kernel::<CHECKED>(row, col)

--- a/isodistrreg/src/total_order/stochastic_dominance/censored/structures.rs
+++ b/isodistrreg/src/total_order/stochastic_dominance/censored/structures.rs
@@ -262,12 +262,54 @@ impl Estimates {
     /// here).
     #[inline(always)]
     pub fn set_value(&mut self, idx: usize, row_idx: usize, value: f32) {
+        // The bound kernels reduce stored values with bare (NaN-propagating) hardware
+        // min/max and the pool comparisons unwrap `partial_cmp`, so a single stored NaN
+        // poisons every later reduction; infinities would survive the clips and corrupt
+        // pooled comparisons the same way. (The diagonal `(NaN, NaN)` bounds sentinel
+        // never reaches a store: `f32::max`/`f32::min` ignore NaN operands.)
+        debug_assert!(value.is_finite(), "stored a non-finite estimator value");
+        // `idx` and `row_idx` must address the SAME cell in the two mirrors — this is the
+        // safety contract of the unchecked stores below and what keeps the mirrors
+        // coherent. Recover (r, s) by inverting the triangle index and recompute the row
+        // index from it.
+        #[cfg(debug_assertions)]
+        {
+            let s = ((8 * idx + 1).isqrt() - 1) / 2;
+            let r = idx - s * (s + 1) / 2;
+            debug_assert!(r <= s && s < self.len, "idx is not a triangle index");
+            debug_assert_eq!(
+                row_idx,
+                Self::compute_row_index((r, s), self.len),
+                "idx and row_idx address different cells (({r}, {s}) vs row_idx {row_idx})",
+            );
+        }
         debug_assert!(idx < self.values.len());
         debug_assert!(row_idx < self.values_row.len());
         // SAFETY: see above — triangle indices of a valid (r, s) cell.
         unsafe {
             *self.values.get_unchecked_mut(idx) = value;
             *self.values_row.get_unchecked_mut(row_idx) = value;
+        }
+    }
+
+    /// Debug-only: the column-major triangle and its row-major mirror must hold bitwise
+    /// identical values at every cell. Every write maintains both copies through
+    /// [`Self::set_value`]; a divergence means some cell was updated through one layout
+    /// only, and the bound kernels — which read the row operand from one mirror and the
+    /// column operand from the other — would silently reduce inconsistent state.
+    #[cfg(debug_assertions)]
+    pub(crate) fn assert_mirrors_coherent(&self) {
+        for r in 0..self.len {
+            for s in r..self.len {
+                let idx = Self::compute_index((r, s), self.len);
+                let row_idx = Self::compute_row_index((r, s), self.len);
+                assert!(
+                    self.values[idx].to_bits() == self.values_row[row_idx].to_bits(),
+                    "value mirrors diverged at ({r}, {s}): {} vs {}",
+                    self.values[idx],
+                    self.values_row[row_idx],
+                );
+            }
         }
     }
 }
@@ -284,6 +326,15 @@ impl Estimates {
     ) -> Self {
         let len = consumed_weight.len();
         debug_assert_eq!(covariate_statistics.len(), len);
+        // The completion queries below test against `start_count - 1`, and the pinning
+        // argument requires the consumed prefix to be all-observed: `accelerated_pava`
+        // stops at the first censored observation, so whenever an interval's last
+        // observation lies inside the prefix, its event bit holds automatically.
+        debug_assert!(start_count >= 1);
+        debug_assert!(
+            observations[..start_count].iter().all(|o| o.observed),
+            "the uncensored-prefix bridge consumed a censored observation",
+        );
 
         let mut estimates = Estimates::new(
             len,
@@ -359,6 +410,10 @@ impl Estimates {
             } else {
                 1.0 - weight_consumed / covariate_statistics[s].weight
             };
+            // Positive covariate weights (preprocessing drops zero-weight observations
+            // and empty covariates) keep the share finite; a non-finite diagonal would
+            // poison the NaN-intolerant kernels like any other stored value.
+            debug_assert!(diag_raw.is_finite());
             let diag_cold = &mut estimates.cold[index];
             diag_cold.raw_value = diag_raw;
             diag_cold.weight = weight_consumed;

--- a/isodistrreg/src/total_order/stochastic_dominance/censored/test.rs
+++ b/isodistrreg/src/total_order/stochastic_dominance/censored/test.rs
@@ -964,6 +964,24 @@ mod differential {
         assert_all_ok(failures);
     }
 
+    /// Signed zeros: the packing sort orders by `total_cmp` (which separates -0.0 from
+    /// +0.0) while the grid and threshold aggregation merge them with `==`. Without the
+    /// pack-time canonicalization the merged threshold 0.0 assembles its events from two
+    /// sort-distinct response groups — not ascending in covariate — and the ±0.0
+    /// covariates carry non-adjacent duplicates past deduplication; both break the
+    /// strictly-ascending run contract the batched PAVA updates (and the debug entry
+    /// asserts) rely on.
+    #[test]
+    fn signed_zero_responses_and_covariates() {
+        let instance = Instance {
+            x: vec![1.0, 2.0, 0.0, -0.0, 3.0, 2.0],
+            y: vec![-0.0, -0.0, 0.0, 5.0, 0.0, -0.0],
+            observed: vec![true, true, true, true, false, false],
+            weights: vec![1.0, 0.75, 1.25, 1.0, 0.5, 1.5],
+        };
+        instance.check().unwrap();
+    }
+
     /// Regression instance for the clip-order divergence. `definition` originally clipped
     /// in (r asc, s asc, k asc) order, where the column-side inputs `(k+1, s)` were not yet
     /// clipped at the current threshold, while `fast` clips against fully-clipped values on

--- a/isodistrreg/src/total_order/stochastic_dominance/censored/test.rs
+++ b/isodistrreg/src/total_order/stochastic_dominance/censored/test.rs
@@ -1010,6 +1010,129 @@ mod differential {
     }
 }
 
+/// One large mixed random instance for the debug-assert battery: in debug builds the
+/// fast algorithm re-validates its invariants on every step (kernel and walk
+/// cross-checks against the scalar reference, partition tiling, mirror coherence,
+/// completion range-maxes, monotonicity, ...), so a single instance combining the
+/// regimes those asserts guard exercises them at a scale the small differential sweeps
+/// cannot reach. The definitional cross-check is far too expensive at this size; release
+/// builds still verify the output is a well-formed isotonic bundle of CDFs.
+///
+/// The generator mixes the regimes deliberately:
+/// - covariate and response each half continuous, half snapped onto coarse grids —
+///   duplicate covariates and long tied-response runs drive the batched updates and the
+///   walk's tie absorption;
+/// - the covariate domain splits into an independent half `[0, 0.5)`, a slightly
+///   positive quarter `[0.5, 0.75)` and a slightly negative quarter `[0.75, 1)` — weak
+///   or adversarial dependence produces the wide pool merges whose long reductions run
+///   the collapse-checkpointed kernels, next to regions whose blocks survive untouched
+///   (blind restores);
+/// - the censoring rate varies smoothly from ~2% to ~55% across the domain with an
+///   extremely censored pocket (97%, containing grid covariates) in `[0.40, 0.45)`, and
+///   the censoring-time shape flips from early censoring (left half) to late censoring
+///   (right half).
+#[test]
+fn large_mixed_stress_instance() {
+    use rand::rngs::StdRng;
+    use rand::{RngExt, SeedableRng};
+
+    // Sized for roughly half a CI minute in debug builds (the assert battery makes the
+    // debug fit itself the expensive part; runtime grows ~n^4 through the threshold
+    // count, so resist enlarging).
+    let mut rng = StdRng::seed_from_u64(0x57e55);
+    let n = 1000;
+    let mut xs = Vec::with_capacity(n);
+    let mut ys = Vec::with_capacity(n);
+    let mut observed = Vec::with_capacity(n);
+    let mut weights = Vec::with_capacity(n);
+    for _ in 0..n {
+        let mut x: f64 = rng.random();
+        if rng.random_bool(0.5) {
+            x = (x * 25.0).floor() / 25.0;
+        }
+        let noise: f64 = rng.random();
+        let event_time = if x < 0.5 {
+            noise
+        } else if x < 0.75 {
+            0.12 * x + 0.88 * noise
+        } else {
+            0.12 * (1.0 - x) + 0.88 * noise
+        };
+        let censor_probability = if (0.40..0.45).contains(&x) {
+            0.97
+        } else {
+            0.02 + 0.53 * x
+        };
+        let censored = rng.random_bool(censor_probability);
+        let mut y = if censored {
+            let fraction: f64 = rng.random();
+            event_time
+                * if x < 0.5 {
+                    fraction * fraction
+                } else {
+                    fraction.sqrt()
+                }
+        } else {
+            event_time
+        };
+        if rng.random_bool(0.5) {
+            y = (y * 40.0).floor() / 40.0;
+        }
+        xs.push(x);
+        ys.push(y);
+        observed.push(!censored);
+        weights.push(rng.random_range(0.5..2.0));
+    }
+
+    let context = preprocess(&xs, &ys, &observed, &weights).unwrap();
+    // Anchor the instance in the regimes the asserts guard, so future generator edits
+    // cannot silently drop coverage: enough covariates for checkpoint-length reductions,
+    // enough censoring for the checkpointed kernel mode (>= 8% share), and tied
+    // responses so the batched updates take their multi-arrival paths.
+    let n_covariate = context.n_covariate();
+    let n_threshold = context.n_threshold();
+    let events = context.observations.iter().filter(|o| o.observed).count();
+    let censored_kept = context.n() - events;
+    assert!(
+        n_covariate > 450,
+        "generator drifted: {n_covariate} covariates"
+    );
+    assert!(
+        n_threshold > 280,
+        "generator drifted: {n_threshold} thresholds"
+    );
+    assert!(
+        censored_kept * 100 >= context.n() * 8,
+        "generator drifted: checkpointed kernel mode not enabled",
+    );
+    assert!(n_threshold < events, "generator drifted: no tied responses");
+
+    let cdfs = fast::algorithm::<Increasing, _, _>(&context, &crate::NoProgress);
+
+    assert_eq!(cdfs.len(), n_threshold * n_covariate);
+    // Well-formedness, meaningful in release builds too: values are probabilities, each
+    // covariate's column is a CDF (non-decreasing in the threshold), and each row of the
+    // increasing fit is antitonic (non-increasing in the covariate) — both up to the
+    // same f32 noise allowance as the debug-side monotonicity asserts.
+    for (t, row) in cdfs.chunks_exact(n_covariate).enumerate() {
+        for (i, &value) in row.iter().enumerate() {
+            assert!((0.0..=1.0).contains(&value), "cdfs[{t}][{i}] = {value}");
+            if i > 0 {
+                assert!(
+                    value <= row[i - 1] + 1e-5,
+                    "row {t} increases along covariates at {i}",
+                );
+            }
+            if t > 0 {
+                assert!(
+                    value >= cdfs[(t - 1) * n_covariate + i] - 1e-5,
+                    "column {i} decreases across thresholds at {t}",
+                );
+            }
+        }
+    }
+}
+
 /// Regression test for exact-1.0 pinning at *intermediate* thresholds
 /// (`CompletionIndex` interleaved into the fast algorithm; the deleted
 /// `pin_completed_mass` post-pass only repaired the final threshold row).

--- a/isodistrreg/src/total_order/stochastic_dominance/routines.rs
+++ b/isodistrreg/src/total_order/stochastic_dominance/routines.rs
@@ -6,6 +6,35 @@ use bitree::BITree;
 use std::cmp::Reverse;
 use std::iter::repeat_n;
 
+/// Slack for the debug-only monotonicity asserts on emitted CDF rows and partition
+/// values. Exact monotonicity is a property of the estimator in exact arithmetic, but not
+/// of the f32 evaluation: batched pooling folds along shorter merge paths, and the
+/// censored collapse checkpoints return midpoints of per-visit checkpoint prefixes that
+/// are mutually unordered — both wobble results by rounding noise (measured elsewhere at
+/// <= ~4e-7). The slack separates that noise from logic bugs, which violate monotonicity
+/// by orders of magnitude more.
+#[cfg(debug_assertions)]
+pub(crate) const MONOTONICITY_NOISE_SLACK: f32 = 1e-5;
+
+/// Debug-only: compare the last two stored CDF rows — the distribution function at each
+/// covariate must be non-decreasing across thresholds (up to
+/// [`MONOTONICITY_NOISE_SLACK`]). Downstream consumers (quantile extraction, the
+/// proper-CDF gates) rely on the emitted rows forming valid CDFs.
+#[cfg(debug_assertions)]
+pub(crate) fn debug_assert_last_rows_monotone(cdf: &[f32], n_covariate: usize) {
+    if cdf.len() < 2 * n_covariate {
+        return;
+    }
+    let tail = &cdf[cdf.len() - 2 * n_covariate..];
+    let (prev, curr) = tail.split_at(n_covariate);
+    for (i, (p, q)) in prev.iter().zip(curr).enumerate() {
+        assert!(
+            *q >= *p - MONOTONICITY_NOISE_SLACK,
+            "CDF decreased across thresholds at covariate {i}: {p} -> {q}",
+        );
+    }
+}
+
 /// Exact bookkeeping of the observations the classical PAVA has consumed so far.
 ///
 /// All weight arithmetic runs in f32 (see the weight contract on `fit()`), so quotients of
@@ -77,6 +106,28 @@ pub fn accelerated_pava<R: PartialOrd + Copy, S: Copy, STOP: Fn(S) -> bool, D: D
         observations.len() - *data_index > 1,
         "Need at least two observations; one to initialize, another to start the loop",
     );
+    // The sort contract the run gathering below silently depends on: observations sorted
+    // by response, and within one response the non-stop observations (events) form one
+    // contiguous prefix with strictly ascending covariates (duplicates aggregated by
+    // preprocessing). Without contiguity a run would end early and the batched update
+    // would evaluate a different estimator than the per-arrival definition.
+    #[cfg(debug_assertions)]
+    for w in observations[*data_index..].windows(2) {
+        let (a, b) = (&w[0], &w[1]);
+        debug_assert!(a.y <= b.y, "observations must be sorted by response");
+        if a.y == b.y {
+            debug_assert!(
+                !stop_condition(a.observed) || stop_condition(b.observed),
+                "a threshold's non-stop observations must precede its stop observations",
+            );
+            if !stop_condition(a.observed) && !stop_condition(b.observed) {
+                debug_assert!(
+                    a.x < b.x,
+                    "a threshold's events must be strictly ascending in covariate",
+                );
+            }
+        }
+    }
 
     let n_covariate = covariate_statistics.len();
 
@@ -138,7 +189,20 @@ pub fn accelerated_pava<R: PartialOrd + Copy, S: Copy, STOP: Fn(S) -> bool, D: D
             return (consumed_share, consumed_weight, partitions);
         }
 
+        #[cfg(debug_assertions)]
+        let cdf_len_before = cdf.len();
         store_in_cdf::<_, D>(&partitions, cdf);
+        #[cfg(debug_assertions)]
+        {
+            // The partition stack must tile the covariate grid exactly — one full row
+            // per threshold — and successive rows must form valid per-covariate CDFs.
+            debug_assert_eq!(
+                cdf.len() - cdf_len_before,
+                n_covariate,
+                "a threshold's partitions did not tile the covariate grid",
+            );
+            debug_assert_last_rows_monotone(cdf, n_covariate);
+        }
         progress.increment();
         active_threshold = observations[*data_index].y;
 
@@ -433,6 +497,31 @@ pub fn update_threshold<R, S, D: Direction>(
     partitions_to_store.clear();
 
     debug_assert!(partitions.is_sorted_by_key(|p| Reverse(p.value)));
+    #[cfg(debug_assertions)]
+    {
+        // The restored stack must tile the covariate grid in storage order (ascending
+        // block boundaries for the decreasing direction, descending for the increasing
+        // direction's reversed storage) — a gap or overlap here silently corrupts every
+        // later threshold. Pooled means divide by the summed block weight and the pool
+        // trichotomy reads finite shares, so both must stay valid through the batched
+        // splits/re-adds/restores.
+        if !D::IS_INCREASING {
+            debug_assert!(partitions.windows(2).all(|w| w[0].index < w[1].index));
+            debug_assert_eq!(partitions.last().unwrap().index, covariate_statistics.len(),);
+        } else {
+            debug_assert!(partitions.windows(2).all(|w| w[0].index > w[1].index));
+            debug_assert_eq!(
+                partitions.first().unwrap().index,
+                covariate_statistics.len(),
+            );
+        }
+        debug_assert!(
+            partitions
+                .iter()
+                .all(|p| p.weight > 0.0 && p.value.is_finite() && p.value >= 0.0),
+            "partition weights must stay positive and values finite non-negative shares",
+        );
+    }
 }
 
 pub fn find_partition_bounds<W, V, D: Direction>(


### PR DESCRIPTION
Includes a tiny bugfix around `-0.0` and `0.0` values.