### PR TITLE
Drop the vestigial osqp R package from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -393,7 +393,7 @@ jobs:
         working-directory: bindings/R
         run: |
           PKG_TARBALL="$(ls -1t ../*.tar.gz | head -n 1)"
-          Rscript -e "install.packages(c('testthat', 'osqp'))"
+          Rscript -e "install.packages(c('testthat'))"
           R CMD check --no-manual --no-build-vignettes "$PKG_TARBALL"
 
   check_r_package_cran:
@@ -425,5 +425,5 @@ jobs:
         working-directory: bindings/R
         run: |
           PKG_TARBALL="$(ls -1t ../*.tar.gz | head -n 1)"
-          Rscript -e "install.packages(c('testthat', 'osqp', 'V8'))"
+          Rscript -e "install.packages(c('testthat', 'V8'))"
           R CMD check --as-cran "$PKG_TARBALL"


### PR DESCRIPTION
The two R check jobs install the CRAN `osqp` package before running `R CMD check`, a leftover from the original pure-R implementation. Nothing uses it any more: `DESCRIPTION` lists only `utils` under Imports and `testthat` under Suggests, and no `library(osqp)`, `require(osqp)` or `osqp::` appears anywhere in `bindings/R` -- not in `R/`, `tests/`, `README.Rmd`, `simulation_example.R`, or the vignette (which is not built, as there is no `VignetteBuilder` field). The package's own quadratic programs are solved by the bundled Rust `osqp` crate, not by the R package.

This only removes the R-level dependency. `cmake` stays in the apt lists: `osqp-sys` still builds the bundled OSQP C sources with it, so those seven entries remain load-bearing.